### PR TITLE
Revert "Merge pull request #7 from digicatapult/chore/Veritable-naming"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=veritable-documentation). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=dscp-documentation). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to veritable-documentation
+# Contributing to dscp-documentation
 
 Firstly, we would like to thank you for taking the time to contribute!
 
@@ -24,7 +24,7 @@ The following is a set of guidelines for contributing to our packages, which are
 
 ## Code of Conduct
 
-This project and all those participating in it are governed by the [Digital Catapult's Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behaviour to [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=veritable-documentation).
+This project and all those participating in it are governed by the [Digital Catapult's Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behaviour to [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=dscp-documentation).
 
 ## FAQs
 
@@ -34,7 +34,7 @@ We don't have any frequently asked questions yet.
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for veritable-documentation. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
+This section guides you through submitting a bug report for dscp-documentation. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
 
 Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/digicatapult/dscp-documentation/blob/main/.github/ISSUE_TEMPLATE/bug_report.md), the information it asks for helps us resolve issues faster.
 
@@ -56,24 +56,24 @@ Explain the problem and include additional details to help maintainers reproduce
 - **Describe the behaviour you observed after following the steps** and point out what exactly is the problem with that behaviour.
 - **Explain which behaviour you expected to see instead and why.**
 - **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. If you use the keyboard while following the steps, \*\*record the GIF with the [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/Xaviju/byzanzUI) on Linux.
-- **If you're reporting that veritable-documentation crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
+- **If you're reporting that dscp-documentation crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
 - **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
 
 Provide more context by answering these questions:
 
-- **Did the problem start happening recently** (e.g. after updating to a new version of veritable-documentation) or was this always a problem?
-- If the problem started happening recently, **can you reproduce the problem in an older version of veritable-documentation?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of veritable-documentation from [the releases page](https://github.com/digicatapult/dscp-documentation/releases).
+- **Did the problem start happening recently** (e.g. after updating to a new version of dscp-documentation) or was this always a problem?
+- If the problem started happening recently, **can you reproduce the problem in an older version of dscp-documentation?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of dscp-documentation from [the releases page](https://github.com/digicatapult/dscp-documentation/releases).
 - **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
 
 Include details about your configuration and environment:
 
-- **Which version of veritable-documentation are you using?** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed veritable-documentation to**?
-- **Are you running veritable-documentation in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
+- **Which version of dscp-documentation are you using?** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed dscp-documentation to**?
+- **Are you running dscp-documentation in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for veritable-documentation, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+This section guides you through submitting an enhancement suggestion for dscp-documentation, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
 Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/digicatapult/dscp-documentation/blob/main/.github/ISSUE_TEMPLATE/feature_request.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
@@ -89,19 +89,19 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 - **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 - **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 - **Describe the current behaviour** and **explain which behaviour you expected to see instead** and why.
-- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of veritable-documentation which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-- **Explain why this enhancement would be useful** to most veritable-documentation users.
+- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of dscp-documentation which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+- **Explain why this enhancement would be useful** to most dscp-documentation users.
 - **List some other text editors or applications where this enhancement exists.**
-- **Specify which version of veritable-documentation you're using.** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed veritable-documentation to**?
+- **Specify which version of dscp-documentation you're using.** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed dscp-documentation to**?
 
 ### Pull Requests
 
 The process described here has several goals:
 
-- Maintain veritable-documentation's quality
+- Maintain dscp-documentation's quality
 - Fix problems that are important to users
-- Enable a sustainable system for veritable-documentation's maintainers to review contributions
+- Enable a sustainable system for dscp-documentation's maintainers to review contributions
 
 Please follow these steps to have your contribution considered by the maintainers:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# **Veritable**
+# **DSCP**
 
-Documentation for Veritable
+Documentation for DSCP
 
-`Veritable` is an open source demonstration of supply chain tracking using `blockchain` technology. `Veritable` enables the sharing of data across organisational boundaries whilst assuring data sensitivity, security, and resilience. The platform has an adaptable design architecture to effectively represent the business logic of real-world operations. It includes features like:
+`DSCP` is the **D**istributed-**S**upply-**C**hain-**P**latform; an open source demonstration of supply chain tracking using `blockchain` technology. `DSCP` enables the sharing of data across organisational boundaries whilst assuring data sensitivity, security, and resilience. The platform has an adaptable design architecture to effectively represent the business logic of real-world operations. It includes features like:
 
 - Immutability of vital metadata for ensuring trust between interacting actors.
 - Distributed file system for secure sharing of large files and data-blobs.
@@ -12,7 +12,7 @@ Documentation for Veritable
 
 ## READMEs
 
-This repo includes READMEs that explain concepts within Veritable:
+This repo includes READMEs that explain concepts within DSCP:
 
 - [Architecture](./docs/architecture.md)
 - [Governance](./docs/governance.md)
@@ -22,31 +22,31 @@ This repo includes READMEs that explain concepts within Veritable:
 
 ## Repositories
 
-### Active Veritable repositories
+### Active DSCP repositories
 
-These repositories contain code being actively maintained as part of the Veritable project.
+These repositories contain code being actively maintained as part of the DSCP project.
 
-| Repository                                                                              | Description                                                                     |
-| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [veritable-documentation](https://github.com/digicatapult/dscp-documentation)           | Documentation for Veritable                                                     |
-| [veritable-flux-infra](https://github.com/digicatapult/dscp-flux-infra)                 | Flux repo to bring up Veritable with Kubernetes                                 |
-| [veritable-node](https://github.com/digicatapult/dscp-node)                             | The blockchain node for Veritable, built with Substrate                         |
-| [veritable-ipfs](https://github.com/digicatapult/dscp-ipfs)                             | IPFS node for Veritable                                                         |
-| [veritable-api](https://github.com/digicatapult/dscp-api)                               | API to create/retrieve tokens on `veritable-node` and files on `veritable-ipfs` |
-| [veritable-identity-service](https://github.com/digicatapult/dscp-identity-service)     | API for managing chain member identities in Veritable                           |
-| [veritable-process-management](https://github.com/digicatapult/dscp-process-management) | Library for managing restricted process flows on `veritable-node`               |
+| Repository                                                                         | Description                                                           |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [dscp-documentation](https://github.com/digicatapult/dscp-documentation)           | Documentation for DSCP                                                |
+| [dscp-flux-infra](https://github.com/digicatapult/dscp-flux-infra)                 | Flux repo to bring up DSCP with Kubernetes                            |
+| [dscp-node](https://github.com/digicatapult/dscp-node)                             | The blockchain node for DSCP, built with Substrate                    |
+| [dscp-ipfs](https://github.com/digicatapult/dscp-ipfs)                             | IPFS node for DSCP                                                    |
+| [dscp-api](https://github.com/digicatapult/dscp-api)                               | API to create/retrieve tokens on `dscp-node` and files on `dscp-ipfs` |
+| [dscp-identity-service](https://github.com/digicatapult/dscp-identity-service)     | API for managing chain member identities in DSCP                      |
+| [dscp-process-management](https://github.com/digicatapult/dscp-process-management) | Library for managing restricted process flows on `dscp-node`          |
 
-### Project-specific Veritable repositories
+### Project-specific DSCP repositories
 
-These repositories contain code written for specific projects that use Veritable.
+These repositories contain code written for specific projects that use DSCP.
 
-| Repository                                               | Description                                                                                     |
-| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [inteli-api](https://github.com/digicatapult/inteli-api) | API for interacting with `veritable-api` and `veritable-identity-service` as an Inteli end-user |
+| Repository                                               | Description                                                                           |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [inteli-api](https://github.com/digicatapult/inteli-api) | API for interacting with `dscp-api` and `dscp-identity-service` as an Inteli end-user |
 
-### Deprecated Veritable repositories
+### Deprecated DSCP repositories
 
-These repositories use Veritable but are now deprecated.
+These repositories use DSCP but are now deprecated.
 
 | Repository                                                                 | Description                                 |
 | -------------------------------------------------------------------------- | ------------------------------------------- |
@@ -55,7 +55,7 @@ These repositories use Veritable but are now deprecated.
 
 ## Lingo
 
-The world of `Blockchain` and `Substrate` is full of lingo. Here's our glossary of what we mean by some of these terms in the context of `Veritable`:
+The world of `Blockchain` and `Substrate` is full of lingo. Here's our glossary of what we mean by some of these terms in the context of `DSCP`:
 
 | Term                 | Means                                                                                                                                                                                                  |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -86,4 +86,4 @@ For more `Substrate` terms see [their glossary](https://docs.substrate.io/refere
 
 ## Contributing
 
-If you want to contribute to `Veritable` that's brilliant! First of all have a look at our contributor guidelines [here](./CONTRIBUTING.md).
+If you want to contribute to `DSCP` that's brilliant! First of all have a look at our contributor guidelines [here](./CONTRIBUTING.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,3 @@
-# Veritable Architecture
+# DSCP Architecture
 
 ![Architecture Diagram](../assets/architecture-v1.svg)

--- a/docs/dataVisibility.md
+++ b/docs/dataVisibility.md
@@ -1,4 +1,4 @@
-# Data visibility in Veritable
+# Data visibility in DSCP
 
 As of writing this piece all metadata information is publicly available. We store information in metadata in the following ways:
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,6 +1,6 @@
 # Governance
 
-This page describes some of the governance procedures within `veritable-node`.
+This page describes some of the governance procedures within `dscp-node`.
 
 ## Create a Vote
 
@@ -10,7 +10,7 @@ To start a new vote select `Proposals`.
 
 ![Governance Tab](../assets/governance/1.png)
 
-On the `Proposals` screen select `Submit proposal` on the right hand side. This will bring up a new proposal which must be made from an initial account, for example, here Alice is creating a proposal. You may notice the use of the doAs pallet, for more information visit [veritable-node](https://github.com/digicatapult/dscp-node/blob/main/README.md#doas-pallet).
+On the `Proposals` screen select `Submit proposal` on the right hand side. This will bring up a new proposal which must be made from an initial account, for example, here Alice is creating a proposal. You may notice the use of the doAs pallet, for more information visit [dscp-node](https://github.com/digicatapult/dscp-node/blob/main/README.md#doas-pallet).
 
 ![Committee Motion](../assets/governance/2.png)
 

--- a/docs/runtimeUpgrade.md
+++ b/docs/runtimeUpgrade.md
@@ -2,15 +2,15 @@
 
 One of Substrate's main features is its support for runtime chain upgrades without forking the code base. Compared to other blockchain frameworks, Substrate makes it easy to add new features to the logic that defines how a chain runs. This is possible because the runtime definition is part of the chain state, meaning it can be validated and set through a chain's usual consensus mechanisms.
 
-This page describes how to upgrade the runtime when using `veritable-node`.
+This page describes how to upgrade the runtime when using `dscp-node`.
 
 ## Prerequisites
 
-A local checkout of [veritable-node](https://github.com/digicatapult/dscp-node) that is successfully running and creating blocks.
+A local checkout of [dscp-node](https://github.com/digicatapult/dscp-node) that is successfully running and creating blocks.
 
 ## Compile upgrade
 
-In a terminal window separate from the currently running `veritable-node`, checkout a branch of a newer runtime that includes any desired changes. For the upgrade to work, `spec_version` in [`runtime/src/lib.rs`](https://github.com/digicatapult/dscp-node/blob/main/runtime/src/lib.rs-node) must be set to a higher number than the current runtime. The current runtime version is also visible in the top-left of [Polkadot Substrate Portal](https://polkadot.js.org/apps/).
+In a terminal window separate from the currently running `dscp-node`, checkout a branch of a newer runtime that includes any desired changes. For the upgrade to work, `spec_version` in [`runtime/src/lib.rs`](https://github.com/digicatapult/dscp-node/blob/main/runtime/src/lib.rs-node) must be set to a higher number than the current runtime. The current runtime version is also visible in the top-left of [Polkadot Substrate Portal](https://polkadot.js.org/apps/).
 
 ![Spec version](../assets/runtimeUpgrade/spec-version.png)
 
@@ -24,11 +24,11 @@ dscp_node_runtime.wasm
 
 ## Submit upgrade
 
-The compiled `wasm` artifact containing the runtime logic can be submitted to the running chain either as an admin user, using Substrate's [`sudo`](https://docs.rs/pallet-sudo/latest/pallet_sudo) pallet, or through a vote, using a custom `veritable` pallet called `doas` alongside Substrate's [`collective`](https://docs.rs/pallet-sudo/latest/pallet_collective) pallet.
+The compiled `wasm` artifact containing the runtime logic can be submitted to the running chain either as an admin user, using Substrate's [`sudo`](https://docs.rs/pallet-sudo/latest/pallet_sudo) pallet, or through a vote, using a custom `dscp` pallet called `doas` alongside Substrate's [`collective`](https://docs.rs/pallet-sudo/latest/pallet_collective) pallet.
 
 ### Sudo
 
-If a chain has an agreed administrator account, that account can be used to upgrade the runtime with `sudo`. This example uses the default `Alice` account that's part of the membership of `veritable-node` when run in `dev` mode.
+If a chain has an agreed administrator account, that account can be used to upgrade the runtime with `sudo`. This example uses the default `Alice` account that's part of the membership of `dscp-node` when run in `dev` mode.
 
 1. Open [Polkadot Substrate Portal](https://polkadot.js.org/apps/) in a browser and connect to the local node.
 2. Go to `Developer` -> `Sudo`.


### PR DESCRIPTION
Reverts https://github.com/digicatapult/dscp-documentation/pull/7 as `DSCP` is staying... for now
